### PR TITLE
feature: kakao login dependecy 추가

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,6 +54,7 @@ android {
 }
 
 dependencies {
+    implementation ("com.kakao.sdk:v2-user:2.19.0") // 카카오 로그인
     // ConstraintLayout
     implementation("androidx.constraintlayout:constraintlayout-compose:1.0.1")
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,6 +24,10 @@
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
+
+                <!-- Redirect URI: "kakao${NATIVE_APP_KEY}://oauth" -->
+                <data android:host="oauth"
+                    android:scheme="kakaoc230900593f912cafc93a3b462d9bd46" />
             </intent-filter>
         </activity>
     </application>

--- a/app/src/main/java/com/tellingus/tellingme/domain/repository/LoginRepository.kt
+++ b/app/src/main/java/com/tellingus/tellingme/domain/repository/LoginRepository.kt
@@ -1,8 +1,12 @@
 package com.tellingus.tellingme.domain.repository
 
+import android.content.Context
 import com.tellingus.tellingme.data.model.DefaultResponse
 import retrofit2.Response
 
 interface LoginRepository {
     suspend fun kakaoLogin(): Response<DefaultResponse>
+    suspend fun isKakaoTalkLoginAvailable(context: Context) // 카카오톡 설치 유무 확인
+    suspend fun loginWithKakaoTalk(context: Context) // 카카오 로그인 with app
+    suspend fun loginWithKakaoAccount(context: Context) // 카카오 로그인 with web
 }

--- a/app/src/main/java/com/tellingus/tellingme/presentation/ui/feature/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/tellingus/tellingme/presentation/ui/feature/mypage/MyPageScreen.kt
@@ -1,9 +1,37 @@
 package com.tellingus.tellingme.presentation.ui.feature.mypage
 
+import android.util.Log
+import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import com.kakao.sdk.user.UserApiClient
 
 @Composable
 fun MyPageScreen() {
+    var TAG: String = "로그"
+    val context = LocalContext.current
     Text(text = "마이 페이지")
+
+
+    Button(onClick = {
+        if (UserApiClient.instance.isKakaoTalkLoginAvailable(context)) {
+            Log.d(TAG, "가능 ${UserApiClient.instance.isKakaoTalkLoginAvailable(context)}")
+        } else {
+            Log.d(TAG, "불가 ${UserApiClient.instance.isKakaoTalkLoginAvailable(context)}")
+            UserApiClient.instance.loginWithKakaoAccount(context) { token, error ->
+                if (error != null) {
+                    Log.e(TAG, "로그인 실패", error)
+                }
+                else if (token != null) {
+                    Log.i(TAG, "로그인 성공 ${token.accessToken}")
+                }
+            }
+        }
+
+
+    }) {
+
+    }
+
 }

--- a/app/src/main/java/com/tellingus/tellingme/util/TellingmeApplication.kt
+++ b/app/src/main/java/com/tellingus/tellingme/util/TellingmeApplication.kt
@@ -1,9 +1,15 @@
 package com.tellingus.tellingme.util
 
 import android.app.Application
+import com.kakao.sdk.common.KakaoSdk
+import com.tellingus.tellingme.R
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
-class TellingmeApplication: Application() {
-
+class TellingmeApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        val kakaoAppKey = getString(R.string.kakao_app_key)
+        KakaoSdk.init(this, kakaoAppKey)
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,6 @@
     <string name="navigation_my_space_text">나의 공간</string>
     <string name="navigation_other_space_text">모두의 공간</string>
     <string name="navigation_my_page_text">MY</string>
+
+    <string name="kakao_app_key">c230900593f912cafc93a3b462d9bd46</string>
 </resources>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,6 +10,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven("https://devrepo.kakao.com/nexus/content/groups/public/") // kakao
     }
 }
 


### PR DESCRIPTION
### 📃 전달 사항
LoginRepository 인터페이스에 카카오 로그인 관련 함수들을 정의해봤습니다. 그러던 중 고민이 생겼네요.
KakaoLoginRepository로 따로 인터페이스를 분리를하는게 나을지 하고요.
다른 소셜로그인들이나, 일반로그인들이 모두 LoginRepository에 뭉쳐있는것보다 좀 더 모듈을 쪼개는게 맞는건지 고민됩니다.
현재 설계한 방식이나 피드백이 있다면 코멘트 부탁드립니다 :)


### 📸 스크린샷



### ✔ 진행사항
- [ ] 카카오 로그인 버튼 구성
- [ ] 카카오 로그인 모듈 구성


### 🔴 ETC
기타 사항을 적어주세요.

실제 개발 기간 : 
