### PR TITLE
Feature/record: Dialog, BottomSheet 관련 기능 추가 

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -78,6 +78,9 @@ dependencies {
     implementation("androidx.work:work-runtime-ktx:2.8.0")
     implementation("androidx.hilt:hilt-navigation-compose:1.0.0")
 
+    // Material detail version
+    implementation("androidx.compose.material3:material3:1.1.1")
+
     implementation("androidx.core:core-ktx:1.9.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.2")
     implementation("androidx.activity:activity-compose:1.8.2")

--- a/app/src/main/java/com/tellingus/tellingme/presentation/ui/common/dialog/DoubleButtonDialog.kt
+++ b/app/src/main/java/com/tellingus/tellingme/presentation/ui/common/dialog/DoubleButtonDialog.kt
@@ -7,15 +7,19 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import com.tellingus.tellingme.presentation.ui.common.button.BUTTON_SIZE
 import com.tellingus.tellingme.presentation.ui.common.button.PrimaryButton
 import com.tellingus.tellingme.presentation.ui.common.button.PrimaryLightButton
@@ -69,6 +73,40 @@ fun DoubleButtonDialog(
                 Spacer(modifier = modifier.size(8.dp))
                 rightButton()
             }
+        }
+    }
+}
+
+@Composable
+fun ShowDoubleButtonDialog(
+    modifier: Modifier = Modifier,
+    title: String,
+    contents: String,
+    leftButton: @Composable RowScope.() -> Unit,
+    rightButton: @Composable RowScope.() -> Unit
+) {
+    Dialog(
+        onDismissRequest = {},
+        properties = DialogProperties(
+            dismissOnBackPress = false,
+            dismissOnClickOutside = false,
+            usePlatformDefaultWidth = false
+        )
+    ) {
+        Surface(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+                .wrapContentHeight(),
+            shape = RoundedCornerShape(20.dp),
+            color = Base0
+        ) {
+            DoubleButtonDialog(
+                title = title,
+                contents = contents,
+                leftButton = leftButton,
+                rightButton = rightButton
+            )
         }
     }
 }

--- a/app/src/main/java/com/tellingus/tellingme/presentation/ui/common/dialog/DoubleButtonDialog.kt
+++ b/app/src/main/java/com/tellingus/tellingme/presentation/ui/common/dialog/DoubleButtonDialog.kt
@@ -1,0 +1,101 @@
+package com.tellingus.tellingme.presentation.ui.common.dialog
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Text
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.tellingus.tellingme.presentation.ui.common.button.BUTTON_SIZE
+import com.tellingus.tellingme.presentation.ui.common.button.PrimaryButton
+import com.tellingus.tellingme.presentation.ui.common.button.PrimaryButtonLargePreview
+import com.tellingus.tellingme.presentation.ui.common.button.PrimaryLightButton
+import com.tellingus.tellingme.presentation.ui.theme.Base0
+import com.tellingus.tellingme.presentation.ui.theme.Gray600
+import com.tellingus.tellingme.presentation.ui.theme.TellingmeTheme
+
+@Composable
+fun DoubleButtonDialog(
+    modifier: Modifier = Modifier,
+    title: String,
+    contents: String,
+    rightButtonText: String,
+    onClickRightButton: () -> Unit,
+    leftButtonText: String,
+    onClickLeftButton: () -> Unit
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
+        colors = CardDefaults.cardColors(Base0),
+        elevation = CardDefaults.cardElevation(0.dp),
+    ) {
+        Column(
+            modifier = modifier
+                .padding(
+                    top = 30.dp,
+                    bottom = 20.dp,
+                    start = 20.dp,
+                    end = 20.dp
+                )
+                .fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = title,
+                style = TellingmeTheme.typography.body1Bold.copy(
+                    color = Gray600
+                )
+            )
+            Spacer(modifier = modifier.size(4.dp))
+            Text(
+                text = contents,
+                style = TellingmeTheme.typography.body2Regular.copy(
+                    color = Gray600
+                )
+            )
+            Spacer(modifier = modifier.size(20.dp))
+
+            Row {
+                PrimaryLightButton(
+                    modifier = modifier.weight(1f),
+                    size = BUTTON_SIZE.LARGE,
+                    text = leftButtonText,
+                    onClick = onClickLeftButton
+                )
+                Spacer(modifier = modifier.size(8.dp))
+                PrimaryButton(
+                    modifier = modifier.weight(1f),
+                    size = BUTTON_SIZE.LARGE,
+                    text = rightButtonText,
+                    onClick = onClickRightButton
+                )
+            }
+        }
+    }
+
+}
+
+@Preview
+@Composable
+fun DoubleButtonDialogPreview() {
+    DoubleButtonDialog(
+        title = "Title",
+        contents = "텍스트",
+        rightButtonText = "완료",
+        leftButtonText = "취소",
+        onClickRightButton = {},
+        onClickLeftButton = {}
+    )
+}

--- a/app/src/main/java/com/tellingus/tellingme/presentation/ui/common/dialog/DoubleButtonDialog.kt
+++ b/app/src/main/java/com/tellingus/tellingme/presentation/ui/common/dialog/DoubleButtonDialog.kt
@@ -47,8 +47,8 @@ fun DoubleButtonDialog(
                 .padding(
                     top = 30.dp,
                     bottom = 20.dp,
-                    start = 20.dp,
-                    end = 20.dp
+                    start = 16.dp,
+                    end = 16.dp
                 )
                 .fillMaxWidth(),
             horizontalAlignment = Alignment.CenterHorizontally

--- a/app/src/main/java/com/tellingus/tellingme/presentation/ui/common/dialog/DoubleButtonDialog.kt
+++ b/app/src/main/java/com/tellingus/tellingme/presentation/ui/common/dialog/DoubleButtonDialog.kt
@@ -1,8 +1,8 @@
 package com.tellingus.tellingme.presentation.ui.common.dialog
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -18,7 +18,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.tellingus.tellingme.presentation.ui.common.button.BUTTON_SIZE
 import com.tellingus.tellingme.presentation.ui.common.button.PrimaryButton
-import com.tellingus.tellingme.presentation.ui.common.button.PrimaryButtonLargePreview
 import com.tellingus.tellingme.presentation.ui.common.button.PrimaryLightButton
 import com.tellingus.tellingme.presentation.ui.theme.Base0
 import com.tellingus.tellingme.presentation.ui.theme.Gray600
@@ -29,10 +28,8 @@ fun DoubleButtonDialog(
     modifier: Modifier = Modifier,
     title: String,
     contents: String,
-    rightButtonText: String,
-    onClickRightButton: () -> Unit,
-    leftButtonText: String,
-    onClickLeftButton: () -> Unit
+    leftButton: @Composable RowScope.() -> Unit,
+    rightButton: @Composable RowScope.() -> Unit
 ) {
     Card(
         modifier = modifier
@@ -68,23 +65,12 @@ fun DoubleButtonDialog(
             Spacer(modifier = modifier.size(20.dp))
 
             Row {
-                PrimaryLightButton(
-                    modifier = modifier.weight(1f),
-                    size = BUTTON_SIZE.LARGE,
-                    text = leftButtonText,
-                    onClick = onClickLeftButton
-                )
+                leftButton()
                 Spacer(modifier = modifier.size(8.dp))
-                PrimaryButton(
-                    modifier = modifier.weight(1f),
-                    size = BUTTON_SIZE.LARGE,
-                    text = rightButtonText,
-                    onClick = onClickRightButton
-                )
+                rightButton()
             }
         }
     }
-
 }
 
 @Preview
@@ -93,9 +79,21 @@ fun DoubleButtonDialogPreview() {
     DoubleButtonDialog(
         title = "Title",
         contents = "텍스트",
-        rightButtonText = "완료",
-        leftButtonText = "취소",
-        onClickRightButton = {},
-        onClickLeftButton = {}
+        leftButton = {
+            PrimaryLightButton(
+                modifier = Modifier.weight(1f),
+                size = BUTTON_SIZE.LARGE,
+                text = "취소",
+                onClick = {}
+            )
+        },
+        rightButton = {
+            PrimaryButton(
+                  modifier = Modifier.weight(1f),
+                  size = BUTTON_SIZE.LARGE,
+                  text = "완료",
+                  onClick = {}
+              )
+        }
     )
 }

--- a/app/src/main/java/com/tellingus/tellingme/presentation/ui/common/dialog/SingleButtonDialog.kt
+++ b/app/src/main/java/com/tellingus/tellingme/presentation/ui/common/dialog/SingleButtonDialog.kt
@@ -1,6 +1,5 @@
 package com.tellingus.tellingme.presentation.ui.common.dialog
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -26,8 +25,7 @@ fun SingleButtonDialog(
     modifier: Modifier = Modifier,
     title: String,
     contents: String,
-    buttonText: String,
-    onClickButton: () -> Unit
+    completeButton: @Composable () -> Unit
 ) {
     Card(
         modifier = modifier
@@ -61,16 +59,9 @@ fun SingleButtonDialog(
                 )
             )
             Spacer(modifier = modifier.size(20.dp))
-
-            PrimaryButton(
-                modifier = modifier.fillMaxWidth(),
-                size = BUTTON_SIZE.LARGE,
-                text = buttonText,
-                onClick = onClickButton
-            )
+            completeButton()
         }
     }
-
 }
 
 @Preview
@@ -79,7 +70,13 @@ fun SingleButtonDialogPreview() {
     SingleButtonDialog(
         title = "Title",
         contents = "텍스트",
-        buttonText = "완료",
-        onClickButton = {}
+        completeButton = {
+            PrimaryButton(
+                modifier = Modifier.fillMaxWidth(),
+                size = BUTTON_SIZE.LARGE,
+                text = "완료",
+                onClick = {}
+            )
+        }
     )
 }

--- a/app/src/main/java/com/tellingus/tellingme/presentation/ui/common/dialog/SingleButtonDialog.kt
+++ b/app/src/main/java/com/tellingus/tellingme/presentation/ui/common/dialog/SingleButtonDialog.kt
@@ -44,8 +44,8 @@ fun SingleButtonDialog(
                 .padding(
                     top = 30.dp,
                     bottom = 20.dp,
-                    start = 20.dp,
-                    end = 20.dp
+                    start = 16.dp,
+                    end = 16.dp
                 )
                 .fillMaxWidth(),
             horizontalAlignment = Alignment.CenterHorizontally

--- a/app/src/main/java/com/tellingus/tellingme/presentation/ui/common/dialog/SingleButtonDialog.kt
+++ b/app/src/main/java/com/tellingus/tellingme/presentation/ui/common/dialog/SingleButtonDialog.kt
@@ -1,19 +1,24 @@
 package com.tellingus.tellingme.presentation.ui.common.dialog
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import com.tellingus.tellingme.presentation.ui.common.button.BUTTON_SIZE
 import com.tellingus.tellingme.presentation.ui.common.button.PrimaryButton
 import com.tellingus.tellingme.presentation.ui.theme.Base0
@@ -64,10 +69,42 @@ fun SingleButtonDialog(
     }
 }
 
+@Composable
+fun ShowSingleButtonDialog(
+    modifier: Modifier = Modifier,
+    title: String,
+    contents: String,
+    completeButton: @Composable () -> Unit
+) {
+    Dialog(
+        onDismissRequest = {},
+        properties = DialogProperties(
+            dismissOnBackPress = false,
+            dismissOnClickOutside = false,
+            usePlatformDefaultWidth = false
+        )
+    ) {
+        Surface(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+                .wrapContentHeight(),
+            shape = RoundedCornerShape(20.dp),
+            color = Base0
+        ) {
+            SingleButtonDialog(
+                title = title,
+                contents = contents,
+                completeButton = completeButton
+            )
+        }
+    }
+}
+
 @Preview
 @Composable
 fun SingleButtonDialogPreview() {
-    SingleButtonDialog(
+    ShowSingleButtonDialog(
         title = "Title",
         contents = "텍스트",
         completeButton = {

--- a/app/src/main/java/com/tellingus/tellingme/presentation/ui/common/dialog/SingleButtonDialog.kt
+++ b/app/src/main/java/com/tellingus/tellingme/presentation/ui/common/dialog/SingleButtonDialog.kt
@@ -1,0 +1,85 @@
+package com.tellingus.tellingme.presentation.ui.common.dialog
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Text
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.tellingus.tellingme.presentation.ui.common.button.BUTTON_SIZE
+import com.tellingus.tellingme.presentation.ui.common.button.PrimaryButton
+import com.tellingus.tellingme.presentation.ui.theme.Base0
+import com.tellingus.tellingme.presentation.ui.theme.Gray600
+import com.tellingus.tellingme.presentation.ui.theme.TellingmeTheme
+
+@Composable
+fun SingleButtonDialog(
+    modifier: Modifier = Modifier,
+    title: String,
+    contents: String,
+    buttonText: String,
+    onClickButton: () -> Unit
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
+        colors = CardDefaults.cardColors(Base0),
+        elevation = CardDefaults.cardElevation(0.dp),
+    ) {
+        Column(
+            modifier = modifier
+                .padding(
+                    top = 30.dp,
+                    bottom = 20.dp,
+                    start = 20.dp,
+                    end = 20.dp
+                )
+                .fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = title,
+                style = TellingmeTheme.typography.body1Bold.copy(
+                    color = Gray600
+                )
+            )
+            Spacer(modifier = modifier.size(4.dp))
+            Text(
+                text = contents,
+                style = TellingmeTheme.typography.body2Regular.copy(
+                    color = Gray600
+                )
+            )
+            Spacer(modifier = modifier.size(20.dp))
+
+            PrimaryButton(
+                modifier = modifier.fillMaxWidth(),
+                size = BUTTON_SIZE.LARGE,
+                text = buttonText,
+                onClick = onClickButton
+            )
+        }
+    }
+
+}
+
+@Preview
+@Composable
+fun SingleButtonDialogPreview() {
+    SingleButtonDialog(
+        title = "Title",
+        contents = "텍스트",
+        buttonText = "완료",
+        onClickButton = {}
+    )
+}

--- a/app/src/main/java/com/tellingus/tellingme/presentation/ui/common/layout/MainLayout.kt
+++ b/app/src/main/java/com/tellingus/tellingme/presentation/ui/common/layout/MainLayout.kt
@@ -3,6 +3,7 @@ package com.tellingus.tellingme.presentation.ui.common.layout
 import android.annotation.SuppressLint
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -21,6 +22,7 @@ fun MainLayout(
     header: @Composable (() -> Unit)? = null,
     content: @Composable () -> Unit,
     background: Color = Background100,
+    isScrollable: Boolean = true
 ) {
     Scaffold(
         modifier = Modifier.background(background),
@@ -29,9 +31,15 @@ fun MainLayout(
             Box(
                 modifier = Modifier
                     .padding(top = if (header != null) 48.dp else 0.dp)
-                    .verticalScroll(
-                        rememberScrollState()
-                    )
+                    .let {
+                        if (isScrollable) {
+                            it.verticalScroll(
+                                rememberScrollState()
+                            )
+                        } else {
+                            it
+                        }
+                    }
             ) {
                 content()
             }

--- a/app/src/main/java/com/tellingus/tellingme/presentation/ui/common/layout/MainLayout.kt
+++ b/app/src/main/java/com/tellingus/tellingme/presentation/ui/common/layout/MainLayout.kt
@@ -25,7 +25,9 @@ fun MainLayout(
     isScrollable: Boolean = true
 ) {
     Scaffold(
-        modifier = Modifier.background(background),
+        modifier = Modifier
+            .background(background)
+            .fillMaxSize(),
         topBar = { header?.let { header() } },
         content = {
             Box(

--- a/app/src/main/java/com/tellingus/tellingme/presentation/ui/common/layout/MainLayout.kt
+++ b/app/src/main/java/com/tellingus/tellingme/presentation/ui/common/layout/MainLayout.kt
@@ -23,12 +23,12 @@ fun MainLayout(
     background: Color = Background100,
 ) {
     Scaffold(
+        modifier = Modifier.background(background),
         topBar = { header?.let { header() } },
         content = {
             Box(
                 modifier = Modifier
                     .padding(top = if (header != null) 48.dp else 0.dp)
-                    .background(background)
                     .verticalScroll(
                         rememberScrollState()
                     )

--- a/app/src/main/java/com/tellingus/tellingme/presentation/ui/feature/home/record/RecordScreen.kt
+++ b/app/src/main/java/com/tellingus/tellingme/presentation/ui/feature/home/record/RecordScreen.kt
@@ -1,6 +1,5 @@
 package com.tellingus.tellingme.presentation.ui.feature.home.record
 
-import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -11,55 +10,46 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.material.ripple.rememberRipple
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.ModalBottomSheetLayout
+import androidx.compose.material.ModalBottomSheetState
+import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
-import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.scale
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
 import com.tellingus.tellingme.R
 import com.tellingus.tellingme.presentation.ui.common.button.BUTTON_SIZE
 import com.tellingus.tellingme.presentation.ui.common.button.PrimaryButton
 import com.tellingus.tellingme.presentation.ui.common.button.PrimaryLightButton
 import com.tellingus.tellingme.presentation.ui.common.button.SingleButton
 import com.tellingus.tellingme.presentation.ui.common.button.TellingmeIconButton
-import com.tellingus.tellingme.presentation.ui.common.dialog.DoubleButtonDialog
 import com.tellingus.tellingme.presentation.ui.common.dialog.ShowDoubleButtonDialog
 import com.tellingus.tellingme.presentation.ui.common.layout.MainLayout
 import com.tellingus.tellingme.presentation.ui.theme.Background100
 import com.tellingus.tellingme.presentation.ui.theme.Base0
-import com.tellingus.tellingme.presentation.ui.theme.Base100
 import com.tellingus.tellingme.presentation.ui.theme.Gray300
 import com.tellingus.tellingme.presentation.ui.theme.Gray500
 import com.tellingus.tellingme.presentation.ui.theme.Gray600
@@ -67,22 +57,51 @@ import com.tellingus.tellingme.presentation.ui.theme.Gray700
 import com.tellingus.tellingme.presentation.ui.theme.Gray800
 import com.tellingus.tellingme.presentation.ui.theme.Primary400
 import com.tellingus.tellingme.presentation.ui.theme.TellingmeTheme
+import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun RecordScreen(
     modifier: Modifier = Modifier,
     navigateToPreviousScreen: () -> Unit
 ) {
-    Surface(
-        modifier = modifier
-            .fillMaxSize()
+    val bottomSheetState = rememberModalBottomSheetState(
+        initialValue = ModalBottomSheetValue.Hidden,
+        skipHalfExpanded = false
+    )
+
+    ModalBottomSheetLayout(
+        sheetState = bottomSheetState,
+        sheetShape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp),
+        sheetBackgroundColor = Background100,
+        sheetContent = {
+            Column(
+                modifier = modifier
+                    .padding(top = 24.dp, start = 16.dp, end = 16.dp, bottom = 8.dp)
+            ) {
+                Text(
+                    text = "이 글 속 나의 감정을 떠올려 봐요",
+                    style = TellingmeTheme.typography.head3Bold,
+                    color = Gray600
+                )
+                Spacer(modifier = modifier.size(4.dp))
+                Text(
+                    text = "행복해요.",
+                    style = TellingmeTheme.typography.body1Regular,
+                    color = Gray600
+                )
+
+                //이 아래로 감정표현 요소들 ~~~
+
+            }
+        }
     ) {
         MainLayout(
             header = {
                 RecordScreenHeader(modifier)
             },
             content = {
-                RecordScreenContent(modifier)
+                RecordScreenContent(modifier, bottomSheetState)
             },
             isScrollable = false
         )
@@ -150,12 +169,15 @@ fun RecordScreenHeader(
     }
 }
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun RecordScreenContent(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    bottomSheetState: ModalBottomSheetState
 ) {
     var recordText by remember { mutableStateOf("") }
     var switchState by remember { mutableStateOf(true) }
+    val scope = rememberCoroutineScope()
 
     Column(
         modifier = modifier.fillMaxSize()
@@ -192,7 +214,16 @@ fun RecordScreenContent(
                     modifier = modifier
                         .padding(horizontal = 16.dp, vertical = 20.dp)
                 ) {
-                    Row {
+                    Row(
+                        modifier = modifier
+                            .clickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = null,
+                                onClick = {
+                                    scope.launch { bottomSheetState.show() }
+                                }
+                            )
+                    ) {
                         Column(
                             horizontalAlignment = Alignment.CenterHorizontally
                         ) {

--- a/app/src/main/java/com/tellingus/tellingme/presentation/ui/feature/home/record/RecordScreen.kt
+++ b/app/src/main/java/com/tellingus/tellingme/presentation/ui/feature/home/record/RecordScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.ripple.rememberRipple
@@ -44,10 +45,15 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import com.tellingus.tellingme.R
 import com.tellingus.tellingme.presentation.ui.common.button.BUTTON_SIZE
+import com.tellingus.tellingme.presentation.ui.common.button.PrimaryButton
+import com.tellingus.tellingme.presentation.ui.common.button.PrimaryLightButton
 import com.tellingus.tellingme.presentation.ui.common.button.SingleButton
 import com.tellingus.tellingme.presentation.ui.common.button.TellingmeIconButton
+import com.tellingus.tellingme.presentation.ui.common.dialog.DoubleButtonDialog
 import com.tellingus.tellingme.presentation.ui.common.layout.MainLayout
 import com.tellingus.tellingme.presentation.ui.theme.Background100
 import com.tellingus.tellingme.presentation.ui.theme.Base0
@@ -86,6 +92,7 @@ fun RecordScreenHeader(
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
+    var showDialogState by remember { mutableStateOf(false) }
 
     Box(
         modifier = modifier
@@ -110,14 +117,69 @@ fun RecordScreenHeader(
             modifier = modifier.align(Alignment.CenterEnd),
             size = BUTTON_SIZE.LARGE,
             text = "완료",
-            onClick = {
-                Toast.makeText(context, "완료클릭",Toast.LENGTH_SHORT).show()
-            }
+            onClick = { showDialogState = !showDialogState }
         )
+
+        if (showDialogState) {
+            ShowDialog(
+                modifier = modifier,
+                onClickLeftButton = {
+                    showDialogState = false
+                },
+                onClickRightButton = {
+                    Toast.makeText(context, "완료 후 홈화면 이동해야 함",Toast.LENGTH_SHORT).show()
+                }
+            )
+        }
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ShowDialog(
+    modifier: Modifier = Modifier,
+    onClickLeftButton: () -> Unit,
+    onClickRightButton: () -> Unit
+) {
+    Dialog(
+        onDismissRequest = {},
+        properties = DialogProperties(
+            dismissOnBackPress = false,
+            dismissOnClickOutside = false,
+            usePlatformDefaultWidth = false
+        )
+    ) {
+        Surface(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+                .wrapContentHeight(),
+            shape = RoundedCornerShape(20.dp),
+            color = Base0
+        ) {
+            DoubleButtonDialog(
+                title = "글을 등록할까요?",
+                contents = "글을 등록하고 나면 감정을 바꿀 수 없어요.",
+                leftButton = {
+                    PrimaryLightButton(
+                        modifier = Modifier.weight(1f),
+                        size = BUTTON_SIZE.LARGE,
+                        text = "취소",
+                        onClick = onClickLeftButton
+                    )
+                },
+                rightButton = {
+                    PrimaryButton(
+                        modifier = Modifier.weight(1f),
+                        size = BUTTON_SIZE.LARGE,
+                        text = "완료",
+                        onClick = onClickRightButton
+                    )
+                }
+            )
+        }
+    }
+}
+
 @Composable
 fun RecordScreenContent(
     modifier: Modifier = Modifier
@@ -250,12 +312,6 @@ fun RecordScreenContent(
             )
         }
     }
-}
-
-@Preview(showBackground = true)
-@Composable
-fun RecordScreenHeaderPreview() {
-    RecordScreenHeader()
 }
 
 @Preview

--- a/app/src/main/java/com/tellingus/tellingme/presentation/ui/feature/home/record/RecordScreen.kt
+++ b/app/src/main/java/com/tellingus/tellingme/presentation/ui/feature/home/record/RecordScreen.kt
@@ -54,6 +54,7 @@ import com.tellingus.tellingme.presentation.ui.common.button.PrimaryLightButton
 import com.tellingus.tellingme.presentation.ui.common.button.SingleButton
 import com.tellingus.tellingme.presentation.ui.common.button.TellingmeIconButton
 import com.tellingus.tellingme.presentation.ui.common.dialog.DoubleButtonDialog
+import com.tellingus.tellingme.presentation.ui.common.dialog.ShowDoubleButtonDialog
 import com.tellingus.tellingme.presentation.ui.common.layout.MainLayout
 import com.tellingus.tellingme.presentation.ui.theme.Background100
 import com.tellingus.tellingme.presentation.ui.theme.Base0
@@ -121,42 +122,8 @@ fun RecordScreenHeader(
         )
 
         if (showDialogState) {
-            ShowDialog(
+            ShowDoubleButtonDialog(
                 modifier = modifier,
-                onClickLeftButton = {
-                    showDialogState = false
-                },
-                onClickRightButton = {
-                    Toast.makeText(context, "완료 후 홈화면 이동해야 함",Toast.LENGTH_SHORT).show()
-                }
-            )
-        }
-    }
-}
-
-@Composable
-fun ShowDialog(
-    modifier: Modifier = Modifier,
-    onClickLeftButton: () -> Unit,
-    onClickRightButton: () -> Unit
-) {
-    Dialog(
-        onDismissRequest = {},
-        properties = DialogProperties(
-            dismissOnBackPress = false,
-            dismissOnClickOutside = false,
-            usePlatformDefaultWidth = false
-        )
-    ) {
-        Surface(
-            modifier = modifier
-                .fillMaxWidth()
-                .padding(horizontal = 20.dp)
-                .wrapContentHeight(),
-            shape = RoundedCornerShape(20.dp),
-            color = Base0
-        ) {
-            DoubleButtonDialog(
                 title = "글을 등록할까요?",
                 contents = "글을 등록하고 나면 감정을 바꿀 수 없어요.",
                 leftButton = {
@@ -164,7 +131,7 @@ fun ShowDialog(
                         modifier = Modifier.weight(1f),
                         size = BUTTON_SIZE.LARGE,
                         text = "취소",
-                        onClick = onClickLeftButton
+                        onClick = { showDialogState = false }
                     )
                 },
                 rightButton = {
@@ -172,7 +139,9 @@ fun ShowDialog(
                         modifier = Modifier.weight(1f),
                         size = BUTTON_SIZE.LARGE,
                         text = "완료",
-                        onClick = onClickRightButton
+                        onClick = {
+                            Toast.makeText(context, "완료 후 홈으로 이동", Toast.LENGTH_SHORT).show()
+                        }
                     )
                 }
             )

--- a/app/src/main/java/com/tellingus/tellingme/presentation/ui/feature/home/record/RecordScreen.kt
+++ b/app/src/main/java/com/tellingus/tellingme/presentation/ui/feature/home/record/RecordScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -75,7 +76,6 @@ fun RecordScreen(
     Surface(
         modifier = modifier
             .fillMaxSize()
-            .background(Background100)
     ) {
         MainLayout(
             header = {
@@ -83,7 +83,8 @@ fun RecordScreen(
             },
             content = {
                 RecordScreenContent(modifier)
-            }
+            },
+            isScrollable = false
         )
     }
 }
@@ -161,7 +162,6 @@ fun RecordScreenContent(
     ) {
         Column(
             modifier = modifier
-                .fillMaxWidth()
                 .weight(1f)
                 .padding(
                     top = 16.dp,
@@ -189,7 +189,8 @@ fun RecordScreenContent(
                 colors = CardDefaults.cardColors(Base0)
             ) {
                 Column(
-                    modifier = modifier.padding(horizontal = 16.dp, vertical = 20.dp)
+                    modifier = modifier
+                        .padding(horizontal = 16.dp, vertical = 20.dp)
                 ) {
                     Row {
                         Column(

--- a/app/src/main/java/com/tellingus/tellingme/presentation/ui/feature/home/record/RecordScreen.kt
+++ b/app/src/main/java/com/tellingus/tellingme/presentation/ui/feature/home/record/RecordScreen.kt
@@ -4,6 +4,8 @@ import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -13,12 +15,16 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
@@ -29,6 +35,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalContext
@@ -50,6 +57,7 @@ import com.tellingus.tellingme.presentation.ui.theme.Gray500
 import com.tellingus.tellingme.presentation.ui.theme.Gray600
 import com.tellingus.tellingme.presentation.ui.theme.Gray700
 import com.tellingus.tellingme.presentation.ui.theme.Gray800
+import com.tellingus.tellingme.presentation.ui.theme.Primary400
 import com.tellingus.tellingme.presentation.ui.theme.TellingmeTheme
 
 @Composable
@@ -115,6 +123,7 @@ fun RecordScreenContent(
     modifier: Modifier = Modifier
 ) {
     var recordText by remember { mutableStateOf("") }
+    var switchState by remember { mutableStateOf(true) }
 
     Column(
         modifier = modifier.fillMaxSize()
@@ -212,10 +221,12 @@ fun RecordScreenContent(
                 }
             }
         }
+
         Row(
             modifier = modifier
                 .fillMaxWidth()
-                .padding(horizontal = 20.dp, vertical = 8.dp)
+                .padding(horizontal = 20.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
                 text = "공개",
@@ -223,6 +234,20 @@ fun RecordScreenContent(
                 color = Gray600
             )
             Spacer(modifier = modifier.size(10.dp))
+            Switch(
+                checked = switchState,
+                onCheckedChange = { switchState = it },
+                colors = SwitchDefaults.colors(
+                    checkedThumbColor = Base0,
+                    checkedTrackColor = Primary400
+                )
+            )
+            Spacer(modifier = modifier.weight(1f))
+            Text(
+                text = "${recordText.length} / 500",
+                style = TellingmeTheme.typography.caption1Bold,
+                color = Gray600
+            )
         }
     }
 }

--- a/app/src/main/java/com/tellingus/tellingme/presentation/ui/feature/home/record/RecordScreen.kt
+++ b/app/src/main/java/com/tellingus/tellingme/presentation/ui/feature/home/record/RecordScreen.kt
@@ -16,21 +16,18 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.ModalBottomSheetLayout
-import androidx.compose.material.ModalBottomSheetState
-import androidx.compose.material.ModalBottomSheetValue
-import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -57,55 +54,21 @@ import com.tellingus.tellingme.presentation.ui.theme.Gray700
 import com.tellingus.tellingme.presentation.ui.theme.Gray800
 import com.tellingus.tellingme.presentation.ui.theme.Primary400
 import com.tellingus.tellingme.presentation.ui.theme.TellingmeTheme
-import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun RecordScreen(
     modifier: Modifier = Modifier,
     navigateToPreviousScreen: () -> Unit
 ) {
-    val bottomSheetState = rememberModalBottomSheetState(
-        initialValue = ModalBottomSheetValue.Hidden,
-        skipHalfExpanded = false
+    MainLayout(
+        header = {
+            RecordScreenHeader(modifier)
+        },
+        content = {
+            RecordScreenContent(modifier)
+        },
+        isScrollable = false
     )
-
-    ModalBottomSheetLayout(
-        sheetState = bottomSheetState,
-        sheetShape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp),
-        sheetBackgroundColor = Background100,
-        sheetContent = {
-            Column(
-                modifier = modifier
-                    .padding(top = 24.dp, start = 16.dp, end = 16.dp, bottom = 8.dp)
-            ) {
-                Text(
-                    text = "이 글 속 나의 감정을 떠올려 봐요",
-                    style = TellingmeTheme.typography.head3Bold,
-                    color = Gray600
-                )
-                Spacer(modifier = modifier.size(4.dp))
-                Text(
-                    text = "행복해요.",
-                    style = TellingmeTheme.typography.body1Regular,
-                    color = Gray600
-                )
-
-                //이 아래로 감정표현 요소들 ~~~
-
-            }
-        }
-    ) {
-        MainLayout(
-            header = {
-                RecordScreenHeader(modifier)
-            },
-            content = {
-                RecordScreenContent(modifier, bottomSheetState)
-            },
-            isScrollable = false
-        )
-    }
 }
 
 @Composable
@@ -169,15 +132,11 @@ fun RecordScreenHeader(
     }
 }
 
-@OptIn(ExperimentalMaterialApi::class)
 @Composable
-fun RecordScreenContent(
-    modifier: Modifier = Modifier,
-    bottomSheetState: ModalBottomSheetState
-) {
+fun RecordScreenContent(modifier: Modifier = Modifier) {
     var recordText by remember { mutableStateOf("") }
     var switchState by remember { mutableStateOf(true) }
-    val scope = rememberCoroutineScope()
+    var isEmotionBottomSheetOpen by remember { mutableStateOf(false) }
 
     Column(
         modifier = modifier.fillMaxSize()
@@ -219,9 +178,7 @@ fun RecordScreenContent(
                             .clickable(
                                 interactionSource = remember { MutableInteractionSource() },
                                 indication = null,
-                                onClick = {
-                                    scope.launch { bottomSheetState.show() }
-                                }
+                                onClick = { isEmotionBottomSheetOpen = true }
                             )
                     ) {
                         Column(
@@ -311,6 +268,49 @@ fun RecordScreenContent(
                 style = TellingmeTheme.typography.caption1Bold,
                 color = Gray600
             )
+        }
+    }
+
+    if (isEmotionBottomSheetOpen) {
+        EmotionBottomSheet(
+            closeSheet = { isEmotionBottomSheetOpen = false }
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EmotionBottomSheet(
+    modifier: Modifier = Modifier,
+    closeSheet: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState()
+
+    ModalBottomSheet(
+        onDismissRequest = closeSheet,
+        sheetState = sheetState,
+        shape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp),
+        containerColor = Background100,
+        dragHandle = null
+    ) {
+        Column(
+            modifier = modifier
+                .padding(top = 24.dp, start = 16.dp, end = 16.dp, bottom = 8.dp)
+        ) {
+            Text(
+                text = "이 글 속 나의 감정을 떠올려 봐요",
+                style = TellingmeTheme.typography.head3Bold,
+                color = Gray600
+            )
+            Spacer(modifier = modifier.size(4.dp))
+            Text(
+                text = "행복해요.",
+                style = TellingmeTheme.typography.body1Regular,
+                color = Gray600
+            )
+
+            //이 아래로 감정표현 요소들 ~~~
+
         }
     }
 }


### PR DESCRIPTION
### 📃 전달 사항
기록하기 상세화면에 들어가는 Dialog와 BottomSheet를 구성했습니다.

### ✔ 진행사항
- 다이어로그 컴포넌트화 (현재는 단일버튼과 더블버튼 두 종류)
- ModalBottomSheetLayout 이용해서 감정을 선택하는 BottomSheet 붙이고 샘플 작성 

### 🔴 ETC
TellingMeScreen에서 ModalBottomSheetLayout가 최상위에서 감싸진게 앱에서 바텀싵 사용이 많다면 컴포넌트 타입을 나눠 사용하기 편리할 것 같아요.
그치만 지금은 확정된 바텀싵 UI가 한 종류 밖에 없어 우선은 RecordScreen에서 ModalBottomSheetLayout 블럭으로 감싸 컴포넌트화하지 않고 작성했습니다!
이후에 바텀싵이 추가되는 형태를 보고 어떻게 할지 고민해보면 좋을 것 같습니다, 일단은 TellingMeScreen의 최상위에 감싸져있는 ModalBottomSheetLayout 블럭은 그대로 두겠습니다 !

실제 개발 기간 : 
